### PR TITLE
Use include "filename"

### DIFF
--- a/main.c
+++ b/main.c
@@ -6,7 +6,8 @@
 #include <string.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
-#include <ssd1306.h>
+
+#include "ssd1306.h"
 
 void print_help()
 {

--- a/ssd1306.c
+++ b/ssd1306.c
@@ -8,9 +8,10 @@
 #include <string.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
-#include <linux_i2c.h>
-#include <ssd1306.h>
-#include <font.h>
+
+#include "linux_i2c.h"
+#include "ssd1306.h"
+#include "font.h"
 
 const char init_oled_type_file[] = "/tmp/.ssd1306_oled_type";
 


### PR DESCRIPTION
Use include "filename" to include programmer-defined header files from the same directory as the file containing the directive. This is needed to avoid the following errors when cross-compiling:

ssd1306.c:11:10: fatal error: linux_i2c.h: No such file or directory
main.c:9:10: fatal error: ssd1306.h: No such file or directory