### PR TITLE
Add option for different i2c address

### DIFF
--- a/main.c
+++ b/main.c
@@ -24,6 +24,7 @@ void print_help()
     printf("-r\t\t0/normal 180/rotate\n");
     printf("-x\t\tx position\n");
     printf("-y\t\ty position\n");
+    printf("-a\t\ti2c address of the display\n");
 }
 
 int main(int argc, char **argv)
@@ -42,10 +43,11 @@ int main(int argc, char **argv)
     int font = 0;
     
     int cmd_opt = 0;
+    uint8_t addr = SSD1306_I2C_ADDR;
     
     while(cmd_opt != -1) 
     {
-        cmd_opt = getopt(argc, argv, "I:c::d:f:hi:l:m:n:r:x:y:");
+        cmd_opt = getopt(argc, argv, "I:c::d:f:hi:l:m:n:r:x:y:a:");
 
         /* Lets parse */
         switch (cmd_opt) {
@@ -97,6 +99,8 @@ int main(int argc, char **argv)
             case 'y':
                 y = atoi(optarg);
                 break;
+            case 'a':
+                addr = strtol(optarg, NULL, 16);
             case -1:
                 // just ignore
                 break;
@@ -142,7 +146,7 @@ int main(int argc, char **argv)
     uint8_t rc = 0;
     
     // open the I2C device node
-    rc = ssd1306_init(i2c_node_address);
+    rc = ssd1306_init(i2c_node_address, addr);
     
     if (rc != 0)
     {

--- a/ssd1306.c
+++ b/ssd1306.c
@@ -21,10 +21,11 @@ static uint8_t max_columns = 0;
 static uint8_t global_x = 0;
 static uint8_t global_y = 0;
 
-uint8_t ssd1306_init(uint8_t i2c_dev)
+uint8_t ssd1306_init(uint8_t i2c_dev, uint8_t addr)
 {
+    if (!addr) addr = SSD1306_I2C_ADDR;
     uint8_t rc;
-    rc = _i2c_init(i2c_dev, SSD1306_I2C_ADDR);
+    rc = _i2c_init(i2c_dev, addr);
     if (rc > 0)
         return rc;
         

--- a/ssd1306.h
+++ b/ssd1306.h
@@ -54,7 +54,7 @@
 #define SSD1306_64_48_COLUMNS       64
 
 
-uint8_t ssd1306_init(uint8_t i2c_dev);
+uint8_t ssd1306_init(uint8_t i2c_dev, uint8_t addr);
 uint8_t ssd1306_end();
 uint8_t ssd1306_oled_onoff(uint8_t onoff);
 uint8_t ssd1306_oled_horizontal_flip(uint8_t flip);


### PR DESCRIPTION
A simple command line option to be able to set different I2C address if using a compatible display (SSD1315) or if the address is redefined using a jumper.